### PR TITLE
DDCYLS-8568 EORI Toolkit: Text is styled as a heading using a <p> tag instead of a semantic <h2>

### DIFF
--- a/app/views/EoriOperationSuccessfulView.scala.html
+++ b/app/views/EoriOperationSuccessfulView.scala.html
@@ -74,7 +74,7 @@
             }
 
 
-            <p class="govuk-heading-m">@messages("eoriUpdate.success.section3")</p>
+            <h2 class="govuk-heading-m">@messages("eoriUpdate.success.section3")</h2>
             <p class="govuk-body">@messages("eoriUpdate.success.section4")</p>
             <p class="govuk-body">@messages("eoriUpdate.success.section5")</p>
         }
@@ -106,7 +106,7 @@
                 </ul>
             }
 
-            <p class="govuk-heading-m">@messages("eoriCancel.success.section3")</p>
+            <h2 class="govuk-heading-m">@messages("eoriCancel.success.section3")</h2>
             <p class="govuk-body">@messages("eoriCancel.success.section4",oldEoriNumber.get)</p>
             <p class="govuk-body">@messages("eoriCancel.success.section5")</p>
         }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -7,7 +7,7 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"   %% s"bootstrap-frontend-$playVersion" % bootstrapVersion,
-    "uk.gov.hmrc"   %% s"play-frontend-hmrc-$playVersion" % "13.5.0",
+    "uk.gov.hmrc"   %% s"play-frontend-hmrc-$playVersion" % "13.7.0",
     "org.typelevel" %% "cats-core"                        % "2.13.0"
   )
 


### PR DESCRIPTION
Changes - 

changed p tag to h2 for correct hierarchy

- amended EoriOperationSuccessfulView.scala.html